### PR TITLE
Adding monochrome-transparent

### DIFF
--- a/monochrome-transparent-theme.el
+++ b/monochrome-transparent-theme.el
@@ -1,0 +1,234 @@
+;;; monochrome-transparent-theme.el --- A dark Emacs 24 theme for your focused hacking sessions
+
+;; Copyright (C) 2011-2014 Xavier Noria
+;;
+;; Author: Xavier Noria <fxn@hashref.com>
+;;
+;; Fork Author: Mauro <mauro@sdf.org>
+;; Keywords: color theme transparent
+;; Version: 1.17.1
+;;
+;; Just throw this file into ~/.emacs.d and
+;;
+;;     M-x load-theme RET monochrome-transparent RET
+;;
+;; or put in your init file
+;;
+;;     (load-theme 'monochrome-transparent)
+;;
+;; This theme is based on the builtin dichromacy theme.
+;;
+;; Works with Emacs 24.
+
+(deftheme monochrome-transparent
+  "Gray on `transparent` for your focused hacking sessions.")
+
+(let ((class '((class color) (min-colors 10)))
+      (black "black")
+      (white "white")
+      (lgray "light gray")
+      (dgray "dark gray")
+      (sgray "light slate gray")
+      (redish "#CE0027")
+      (greenish "#28FC91")
+      (yellowish "#E9FF3F"))
+
+  (custom-theme-set-faces
+   'monochrome-transparent
+
+   `(default ((,class (:foreground ,lgray :background nil))))
+   `(cursor ((,class (:background ,lgray))))
+
+   ;; Highlighting faces
+   `(fringe ((,class (:foreground ,black :background ,lgray))))
+   `(highlight ((,class (:foreground ,black :background ,lgray))))
+   `(region ((,class (:foreground ,black :background ,lgray))))
+   `(secondary-selection ((,class (:foreground: ,black :background ,sgray))))
+   `(isearch ((,class (:foreground ,black :background ,lgray))))
+   `(lazy-highlight ((,class (:foreground ,black :background ,lgray))))
+   `(linum ((,class (:foreground ,dgray :slant italic))))
+   `(trailing-whitespace ((,class (:background ,redish))))
+
+   ;; Mode line faces
+   `(mode-line ((,class (:box (:line-width -1 :style released-button)
+			      :background nil :foreground ,white))))
+   `(mode-line-inactive ((,class (:box (:line-width -1 :style released-button)
+				       :background nil
+				       :foreground ,white))))
+
+   ;; Whitespace-mode
+   `(whitespace-empty ((,class (:background unspecified :foreground ,redish))))
+   `(whitespace-line ((,class (:background ,lgray :foreground ,black))))
+
+   ;; Escape and prompt faces
+   `(minibuffer-prompt ((,class (:weight bold :foreground ,lgray))))
+   `(escape-glyph ((,class (:foreground ,lgray))))
+   `(error ((,class (:weight bold :slant italic :foreground ,redish))))
+   `(warning ((,class (:foreground ,yellowish))))
+   `(success ((,class (:foreground ,greenish))))
+
+   ;; Font lock faces
+   `(font-lock-builtin-face ((,class (:foreground ,lgray))))
+   `(font-lock-comment-face ((,class (:slant italic :foreground ,dgray))))
+   `(font-lock-constant-face ((,class (:weight bold :foreground ,lgray))))
+   `(font-lock-function-name-face ((,class (:weight bold :foreground ,white))))
+   `(font-lock-keyword-face ((,class (:weight bold :foreground ,white))))
+   `(font-lock-string-face ((,class (:weight bold :foreground ,white))))
+   `(font-lock-type-face ((,class (:weight bold :foreground ,lgray))))
+   `(font-lock-variable-name-face ((,class (:weight bold :foreground ,white))))
+   `(font-lock-warning-face ((,class (:foreground ,yellowish))))
+
+   ;; Button and link faces
+   `(link ((,class (:underline t :foreground ,lgray))))
+   `(link-visited ((,class (:underline t :foreground ,lgray))))
+
+   ;; Show-paren
+   `(show-paren-match ((t (:background ,sgray))))
+   `(show-paren-mismatch ((t (:background ,redish))))
+
+   ;; Speedbar
+   `(speedbar-button-face ((,class (:foreground ,dgray))))
+   `(speedbar-file-face ((,class (:foreground ,lgray))))
+   `(speedbar-directory-face ((,class (:weight bold :foreground ,white))))
+   `(speedbar-tag-face ((,class (:foreground ,dgray))))
+   `(speedbar-selected-face ((,class (:underline ,lgray :foreground ,lgray))))
+   `(speedbar-highlight-face ((,class (:weight bold :background ,black :foreground ,white))))
+
+   ;; ido
+   `(ido-first-match ((,class (:foreground ,lgray))))
+   `(ido-only-match ((,class (:underline ,lgray :foreground ,lgray))))
+   `(ido-subdir ((,class (:weight bold :foreground ,white))))
+
+   ;; MuMaMo
+   `(mumamo-background-chunk-major ((,class (:background ,black))))
+   `(mumamo-background-chunk-submode1 ((,class (:background ,black))))
+   `(mumamo-background-chunk-submode2 ((,class (:background ,black))))
+   `(mumamo-background-chunk-submode3 ((,class (:background ,black))))
+   `(mumamo-background-chunk-submode4 ((,class (:background ,black))))
+   `(mumamo-border-face-in ((,class (:slant unspecified :underline unspecified
+                                     :weight bold :foreground ,white))))
+   `(mumamo-border-face-out ((,class (:slant unspecified :underline unspecified
+                                      :weight bold :foreground ,white))))
+
+   ;; Gnus faces
+   `(gnus-group-news-1 ((,class (:weight bold :foreground ,lgray))))
+   `(gnus-group-news-1-low ((,class (:foreground ,lgray))))
+   `(gnus-group-news-2 ((,class (:weight bold :foreground ,lgray))))
+   `(gnus-group-news-2-low ((,class (:foreground ,lgray))))
+   `(gnus-group-news-3 ((,class (:weight bold :foreground ,lgray))))
+   `(gnus-group-news-3-low ((,class (:foreground ,lgray))))
+   `(gnus-group-news-4 ((,class (:weight bold :foreground ,lgray))))
+   `(gnus-group-news-4-low ((,class (:foreground ,lgray))))
+   `(gnus-group-news-5 ((,class (:weight bold :foreground ,lgray))))
+   `(gnus-group-news-5-low ((,class (:foreground ,lgray))))
+   `(gnus-group-news-low ((,class (:foreground ,lgray))))
+   `(gnus-group-mail-1 ((,class (:weight bold :foreground ,lgray))))
+   `(gnus-group-mail-1-low ((,class (:foreground ,lgray))))
+   `(gnus-group-mail-2 ((,class (:weight bold :foreground ,lgray))))
+   `(gnus-group-mail-2-low ((,class (:foreground ,lgray))))
+   `(gnus-group-mail-3 ((,class (:weight bold :foreground ,lgray))))
+   `(gnus-group-mail-3-low ((,class (:foreground ,lgray))))
+   `(gnus-group-mail-low ((,class (:foreground ,lgray))))
+   `(gnus-header-content ((,class (:foreground ,lgray))))
+   `(gnus-header-from ((,class (:weight bold :foreground ,lgray))))
+   `(gnus-header-subject ((,class (:foreground ,lgray))))
+   `(gnus-header-name ((,class (:foreground ,lgray))))
+   `(gnus-header-newsgroups ((,class (:foreground ,lgray))))
+
+   ;; Message faces
+   `(message-header-name ((,class (:foreground ,lgray))))
+   `(message-header-cc ((,class (:foreground ,lgray))))
+   `(message-header-other ((,class (:foreground ,lgray))))
+   `(message-header-subject ((,class (:foreground ,lgray))))
+   `(message-header-to ((,class (:weight bold :foreground ,lgray))))
+   `(message-cited-text ((,class (:slant italic :foreground ,lgray))))
+   `(message-separator ((,class (:weight bold :foreground ,lgray))))
+
+   ;; EShell
+   `(eshell-prompt ((,class (:foreground ,white :bold t))))
+   `(eshell-ls-archive ((,class (:inherit eshell-ls-unreadable))))
+   `(eshell-ls-backup ((,class (:inherit eshell-ls-unreadable))))
+   `(eshell-ls-clutter ((,class (:inherit eshell-ls-unreadable))))
+   `(eshell-ls-directory ((,class (:foreground ,lgray :bold t))))
+   `(eshell-ls-executable ((,class (:inherit eshell-ls-unreadable))))
+   `(eshell-ls-missing ((,class (:inherit eshell-ls-unreadable))))
+   `(eshell-ls-product ((,class (:inherit eshell-ls-unreadable))))
+   `(eshell-ls-readonly ((,class (:inherit eshell-ls-unreadable))))
+   `(eshell-ls-special ((,class (:inherit eshell-ls-unreadable))))
+   `(eshell-ls-symlink ((,class (:inherit eshell-ls-unreadable))))
+
+   ;; Org-mode
+   `(org-level-1 ((t (:bold t :foreground ,lgray :height 1.5))))
+   `(org-level-2 ((t (:bold nil :foreground ,lgray :height 1.2))))
+   `(org-level-3 ((t (:bold t :foreground ,lgray :height 1.0))))
+   `(org-level-4 ((t (:bold nil :foreground ,lgray :height 1.0))))
+   `(org-link ((t (:foreground ,sgray :underline t))))
+   `(org-todo ((t (:bold t :foreground ,redish))))
+   `(org-done ((t (:bold t :foreground ,greenish))))
+
+   ;; helm
+   `(helm-header ((t (:foreground ,dgray :background ,black :underline nil :box nil))))
+   `(helm-source-header
+     ((t (:foreground ,white
+                      :background ,black
+                      :underline nil
+                      :weight bold
+                      :box (:line-width 1 :style released-button)))))
+   `(helm-selection ((t (:background ,lgray :underline t :foreground ,black))))
+   `(helm-selection-line ((t (:background ,black))))
+   `(helm-visible-mark ((t (:foreground ,black :background ,white))))
+   `(helm-candidate-number ((t (:foreground ,lgray :background ,black))))
+   `(helm-separator ((t (:foreground ,white :background ,black))))
+   `(helm-time-zone-current ((t (:foreground ,lgray :background ,black))))
+   `(helm-time-zone-home ((t (:foreground ,white :background ,black))))
+   `(helm-bookmark-addressbook ((t (:foreground ,lgray :background ,black))))
+   `(helm-bookmark-directory ((t (:foreground nil :background nil :inherit helm-ff-directory))))
+   `(helm-bookmark-file ((t (:foreground nil :background nil :inherit helm-ff-file))))
+   `(helm-bookmark-gnus ((t (:foreground ,white :background ,black))))
+   `(helm-bookmark-info ((t (:foreground ,lgray :background ,black))))
+   `(helm-bookmark-man ((t (:foreground ,white :background ,black))))
+   `(helm-bookmark-w3m ((t (:foreground ,white :background ,black))))
+   `(helm-buffer-not-saved ((t (:foreground ,white :background ,black))))
+   `(helm-buffer-process ((t (:foreground ,white :background ,black))))
+   `(helm-buffer-saved-out ((t (:foreground ,lgray :background ,black))))
+   `(helm-buffer-size ((t (:foreground ,lgray :background ,black))))
+   `(helm-ff-directory ((t (:foreground ,white :background ,black :weight bold))))
+   `(helm-ff-file ((t (:foreground ,lgray :background ,black :weight normal))))
+   `(helm-ff-executable ((t (:foreground ,lgray :background ,black :weight normal))))
+   `(helm-ff-invalid-symlink ((t (:foreground ,white :background ,black :weight bold))))
+   `(helm-ff-symlink ((t (:foreground ,white :background ,black :weight bold))))
+   `(helm-ff-prefix ((t (:foreground ,black :background ,white :weight normal))))
+   `(helm-grep-cmd-line ((t (:foreground ,white :background ,black))))
+   `(helm-grep-file ((t (:foreground ,lgray :background ,black))))
+   `(helm-grep-finish ((t (:foreground ,lgray :background ,black))))
+   `(helm-grep-lineno ((t (:foreground ,lgray :background ,black))))
+   `(helm-grep-match ((t (:foreground nil :background nil :inherit helm-match))))
+   `(helm-grep-running ((t (:foreground ,white :background ,black))))
+   `(helm-moccur-buffer ((t (:foreground ,white :background ,black))))
+   `(helm-mu-contacts-address-face ((t (:foreground ,lgray :background ,black))))
+   `(helm-mu-contacts-name-face ((t (:foreground ,lgray :background ,black))))
+
+   ;; Flyspell
+   `(flyspell-duplicate ((,class (:weight unspecified :foreground unspecified
+				  :slant unspecified :underline ,lgray))))
+   `(flyspell-incorrect ((,class (:weight unspecified :foreground unspecified
+				  :slant unspecified :underline ,lgray)))))
+
+  (custom-theme-set-variables
+   'monochrome-transparent
+   `(ansi-color-names-vector [,black ,lgray ,dgray ,sgray ,redish ,greenish ,yellowish])))
+
+;; Autoload for MELPA
+
+;;;###autoload
+(when (and (boundp 'custom-theme-load-path) load-file-name)
+  (add-to-list 'custom-theme-load-path
+               (file-name-as-directory (file-name-directory load-file-name))))
+
+(provide-theme 'monochrome-transparent)
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
+;;; monochrome-transparent-theme.el ends here

--- a/monochrome-transparent-theme.el
+++ b/monochrome-transparent-theme.el
@@ -48,6 +48,8 @@
    `(lazy-highlight ((,class (:foreground ,black :background ,lgray))))
    `(linum ((,class (:foreground ,dgray :slant italic))))
    `(trailing-whitespace ((,class (:background ,redish))))
+   `(pulse-highlight-face ((,class (:foreground, black :background ,lgray))))
+   `(pulse-highlight-start-face ((,class (:foreground, black :background ,lgray))))
 
    ;; Mode line faces
    `(mode-line ((,class (:box (:line-width -1 :style released-button)


### PR DESCRIPTION
Hi! 
Added a new alternative to the monochrome theme which keeps the same colors but the backgrounds are `nil`, also replaced some of the colors to something less generic (instead of `"red"` it's `"#CE0027"`).

